### PR TITLE
Python3 exception handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+bin
+site-packages
 *.pyc
+pyvenv.cfg

--- a/fldb.py
+++ b/fldb.py
@@ -118,7 +118,7 @@ class DatabasePool:
                 test_cur.execute("SELECT 42;")
                 test_cur.close()
                 break
-            except psycopg2.DatabaseError, psycopg2.OperationalError:
+            except (psycopg2.DatabaseError, psycopg2.OperationalError):
                 pass
         else:
             raise RuntimeError('Could not get a connection to: {}'.format(self.name))


### PR DESCRIPTION
The exception catching syntax is incompatible with python 3, and according to [PEP-3110](https://www.python.org/dev/peps/pep-3110/) is wrong for [python2](https://www.python.org/dev/peps/pep-3110/#rationale).

The compatible style and standard style for python 3 is to use a tuple,
https://docs.python.org/3/tutorial/errors.html#handling-exceptions

Updated exception handling accordingly.
