### PR TITLE
Code cleanup & fixed exception with trying to close un-initialized pool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,18 +3,18 @@
 from setuptools import setup
 
 with open('requirements.txt') as f:
-  required = f.read().splitlines()
+  install_requires = f.read().splitlines()
 
 NAME = 'fldb'
-VERSION = '0.0.1'
+VERSION = '1.0.0'
 
 setup(**{
-  'author': 'FarmLogs',
-  'author_email': 'engineering@farmlogs.com',
-  'download_url': 'https://github.com/FarmLogs/%s/tarball/%s' % (NAME, VERSION, ),
-  'install_requires': required,
-  'name': NAME,
-  'py_modules': [NAME],
-  'url': 'https://github.com/FarmLogs/%s' % NAME,
-  'version': VERSION,
+    'author': 'FarmLogs',
+    'author_email': 'engineering@farmlogs.com',
+    'download_url': 'https://github.com/FarmLogs/%s/tarball/%s' % (NAME, VERSION, ),
+    'install_requires': install_requires,
+    'name': NAME,
+    'py_modules': [NAME],
+    'url': 'https://github.com/FarmLogs/%s' % NAME,
+    'version': VERSION,
 })

--- a/tests.py
+++ b/tests.py
@@ -1,13 +1,17 @@
 import os
 import unittest
-import pprint
 
 from fldb import FLDB
+
 
 class TestBasicCases(unittest.TestCase):
   def setUp(self):
     self.conn = FLDB.from_name('TEST_DATABASE_URL')
     self.people = ['Ashley', 'Frank', 'Mason']
+
+  def test_teardown_works(self):
+    x = FLDB.from_url('invalid://url')
+    del x
 
   def test_same_db(self):
     """


### PR DESCRIPTION
Previously if you ran something like the following (or if Python tried to garbage collect the object):

```python
x = FLDB.from_url('invalid://url')
del x
```

You'd get the following error:

```
Exception AttributeError: "'DatabasePool' object has no attribute '_pool'" in <bound method DatabasePool.__del__ of <DatabasePool: postgres://postgres:null@db/test_db>> ignored
```

This would occur because the pool was never initialized properly and therefor didn't exist yet.

Now the `__del__` code checks for this. A test was also added to ensure this new behavior works.

Also in this PR, 

- The Pool is lazily instantiated so that connections do not get created until the first time they are needed
- Default arguments are no longer specified in the function declaration to prevent issues there.