### PR TITLE
Update psycopg2 to postgres 10 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-psycopg2==2.6.2
+psycopg2==2.7.5


### PR DESCRIPTION
Postgres 10 requires a newer version of psycopg2:

https://github.com/psycopg/psycopg2/issues/489